### PR TITLE
check_boot_jars: Add oplus package names to allowed list

### DIFF
--- a/scripts/check_boot_jars/package_allowed_list.txt
+++ b/scripts/check_boot_jars/package_allowed_list.txt
@@ -269,6 +269,8 @@ com\.nvidia\..*
 
 # OPLUS adds
 com\.oplus\..*
+net\.oneplus\..*
+oplus\..*
 
 # QC adds
 com.qualcomm.qti


### PR DESCRIPTION
Change-Id: I962d7868fefc5a9bf73af3c6c9c81c27813d5fa9
this commit solves given build error: 

_Error: out/soong/.intermediates/hardware/oplus/oplus-fwk/oplus-fwk/android_common/7bd916565615329d50364be05485f3c9/aligned/oplus-fwk.jar contains class file net.oneplus.odm.OpDeviceManagerInjector, whose package name "net.oneplus.odm" is empty or not in the allow list build/soong/scripts/check_boot_jars/package_allowed_list.txt of packages allowed on the bootclasspath._

picked from here:
https://github.com/pjgowtham/android_build_soong/commit/b4050f107974f1756da6da257e3293f499eb9cb6

or you can pick from here:
https://github.com/Evolution-X/build_soong/commit/0fb260f483afab36070ff85f40e41aaef988d5b7